### PR TITLE
added npm run dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ An Unified Operating System on the web.[For Demo](https://rajagopalan-gangadhara
       `cd JS-OS`
 3. Install all dependencies      
       `npm install`     
-4. Start Local Server      
-      `npm start`
-5. Run the app in development mode
+4. Go to src/server       
+      `npm install`
+5. Go to main directory & Run `npm run dev` to start developement mode.
 Open `[http://localhost:3000](http://localhost:3000)` to view in the browser. 
 
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,10 @@
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d build",
+    "client": "npm start",
+    "server": "cd src/server && nodemon index.js",
+    "dev": "concurrently \"npm run server \" \"npm run client\""
   },
   "devDependencies": {
     "gh-pages": "^2.0.1"


### PR DESCRIPTION
fixed #28 
Now we can use `npm run dev` in main folder which will start both server and front end
![packagejson-JS-OSWSL-VisualStudi](https://user-images.githubusercontent.com/40923324/71416049-d340cf80-2684-11ea-9296-079e8ac1f711.gif)
