### PR TITLE
save contents & file

### DIFF
--- a/src/defaultapps/texteditor/editor.css
+++ b/src/defaultapps/texteditor/editor.css
@@ -1,0 +1,3 @@
+.editor{
+    margin-top: 0px;
+}

--- a/src/defaultapps/texteditor/editor.js
+++ b/src/defaultapps/texteditor/editor.js
@@ -1,36 +1,107 @@
 import React from 'react';
 import { render } from 'react-dom';
 import MonacoEditor from 'react-monaco-editor';
+import "./editor.css"
+
+class MenuBar extends React.Component{
+  constructor(props){
+    super(props);
+    this.state = {
+      toSave : false
+    }
+  }
+  handleChange(){
+    this.setState({
+      toSave : !this.state.toSave
+    })
+  }
+
+  createFile(){
+    var f = document.getElementById("fileName").value
+    console.log(f)
+    var c = this.props.code
+    console.log(c)
+    fetch("http://localhost:3020/fs/createFile",{
+    method: 'POST',
+    body: JSON.stringify({Name: f, Content: c }),
+    headers: {
+        'Content-Type': 'application/json'
+    }
+    }).then(data => console.log(data.json()))
+
+  }
+
+  render(){
+    const {toSave} = this.state
+    if(!toSave){
+      return(
+        <div>
+          <button onClick={()=>this.handleChange()}>Save</button>
+        </div>
+      )
+    }else{
+      return(
+        <div>
+          <input id="fileName" placeholder="Enter file name"/>
+          <button onClick={()=>{this.handleChange(); this.createFile()}}>Ok</button>
+        </div>
+      )
+    }
+  }
+}
+
 
 class Editor extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       code: '// type your code...',
+      content : ''
     }
   }
+  
   editorDidMount(editor, monaco) {
     console.log('editorDidMount', editor);
     editor.focus();
+    var c = editor.getModel();
+    var v = c.getValue()
+    console.log(v)
   }
-  onChange(newValue, e) {
-    console.log('onChange', newValue, e);
+  updateChange(f){
+    this.setState({
+      code : f
+    })
+  }
+  onChange = (newValue, e) => {
+    console.log('onChange', newValue,e);
+    this.updateChange(newValue);
   }
   render() {
-    const code = this.state.code;
+    const code = this.state.code
     const options = {
       selectOnLineNumbers: true,
       automaticLayout:true
     };
     return (
-      <MonacoEditor
-        language="javascript"
-        theme="vs-dark"
-        value={code}
-        options={options}
-        onChange={this.onChange}
-        editorDidMount={this.editorDidMount}
-      />
+        <div>
+          <div>
+            <MenuBar code={this.state.code}/>
+          </div>
+          <div className="editor">
+              <MonacoEditor
+              width="100%"
+              height="400"
+              id="edit"
+              language="javascript"
+              theme="vs-dark"
+              value={code}
+              options={options}
+              onChange={this.onChange}
+              editorDidMount={this.editorDidMount}
+            />
+          </div>
+        </div>
+       
     );
   }
 }


### PR DESCRIPTION
fixes #2 
Finally got to work on the code editor.
Added a functionality to create and save a new file along with contents typed in our filesystem.
We can read the contents using `cat` command from terminal.

![JS-OS-GoogleChrome2019-12-3022-1](https://user-images.githubusercontent.com/40923324/71591519-aabc4800-2b52-11ea-8f5f-04365ff2a489.gif)
